### PR TITLE
Make empty CPANfile well behaved

### DIFF
--- a/lib/Module/CPANfile.pm
+++ b/lib/Module/CPANfile.pm
@@ -22,7 +22,7 @@ BEGIN {
 
 sub new {
     my($class, $file) = @_;
-    bless {}, $class;
+    bless { _prereqs => Module::CPANfile::Prereqs->new }, $class;
 }
 
 sub load {

--- a/t/fresh.t
+++ b/t/fresh.t
@@ -1,0 +1,16 @@
+
+use strict;
+use Module::CPANfile;
+use Test::More;
+
+# Calling public methods on an empty cpanfile
+{
+    my $file = Module::CPANfile->new;
+
+    is_deeply( $file->prereqs, CPAN::Meta::Prereqs->new,
+        'Module::CPANfile->new->prereqs' );
+    is_deeply( $file->prereq_specs, {}, 'Module::CPANfile->new->prereq_specs' );
+    is_deeply( [ $file->features ], [], 'Module::CPANfile->new->features' );
+    is( $file->to_string, '', 'Module::CPANfile->new->to_string' );
+}
+done_testing;


### PR DESCRIPTION
avoiding exceptions on calls like

    Module::CPANfile->new->to_string;
    Module::CPANfile->new->prereqs;

This is also compatible with the behavior one can get from

    Module::CPANfile->from_prereqs({});